### PR TITLE
Added exec to entrypoint daemon processes, dns-client can be sigkilled

### DIFF
--- a/dockerfiles/Dockerfile.dnsclient
+++ b/dockerfiles/Dockerfile.dnsclient
@@ -29,3 +29,4 @@ RUN cd /root && \
 
 COPY --chmod=755 entrypoints/entrypoint_dnsclient.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
+STOPSIGNAL SIGKILL

--- a/entrypoints/entrypoint_dnsclient.sh
+++ b/entrypoints/entrypoint_dnsclient.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-sleep infinity
+exec sleep infinity

--- a/entrypoints/entrypoint_knotd.sh
+++ b/entrypoints/entrypoint_knotd.sh
@@ -3,4 +3,4 @@ if [ "$HOSTNAME" != knot-fakeroot ] && [ "$HOSTNAME" != knot-secondlevel ]; then
    rm /var/lib/knot/zones/* /var/lib/knot/journal/* > /dev/null 2>&1
 fi
 chown --recursive knot:knot /run/knot/ /var/lib/knot /etc/knot
-knotd
+exec knotd

--- a/entrypoints/entrypoint_nsd.sh
+++ b/entrypoints/entrypoint_nsd.sh
@@ -13,4 +13,4 @@ if [ "$HOSTNAME" == nsd-validator ]; then
    # - verifier script that provides workaround for missing zonefile (files/nsd-validator/verify.sh)
    mkdir -p /var/lib/knot/zones/
 fi
-nsd -d
+exec nsd -d

--- a/entrypoints/entrypoint_unbound.sh
+++ b/entrypoints/entrypoint_unbound.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-unbound -d
+exec unbound -d


### PR DESCRIPTION
Added exec to entrypoint daemon processes, dns-client can safely be sigkilled