### PR TITLE
Use latest stable Knot from CZ.NIC

### DIFF
--- a/dockerfiles/Dockerfile.knotd
+++ b/dockerfiles/Dockerfile.knotd
@@ -4,10 +4,15 @@
 FROM ubuntu:latest
 
 RUN export DEBIAN_FRONTEND=noninteractive; \
-    apt-get update && apt-get upgrade -y && apt-get -y -qq install --no-install-recommends \
+    apt-get update && apt-get -y -qq install --no-install-recommends \
+    ca-certificates \
+    lsb-release \
+    wget \
+&&  wget -O /usr/share/keyrings/cznic-labs-pkg.gpg https://pkg.labs.nic.cz/gpg \
+&&  echo "deb [signed-by=/usr/share/keyrings/cznic-labs-pkg.gpg] https://pkg.labs.nic.cz/knot-dns $(lsb_release -sc) main" > /etc/apt/sources.list.d/cznic-labs-knot-dns.list \
+&&  apt-get update && apt-get upgrade -y && apt-get -y -qq install --no-install-recommends \
     coreutils \
     curl \
-    ca-certificates \
     git-core \
     vim \
     dnsutils \


### PR DESCRIPTION
Inspired by https://pkg.labs.nic.cz/doc/scripts/enable-repo-cznic-labs.sh